### PR TITLE
Fix: missing response content

### DIFF
--- a/converter/ResponseBodyConverter.py
+++ b/converter/ResponseBodyConverter.py
@@ -44,6 +44,9 @@ def __get_response_body(content_type: str, body_content: dict, body_components: 
 
 def get_response_content(response_content: dict, components: dict) -> list[Content]:
     bodies = []
-    for body, body_content in response_content['content'].items():
-        bodies.append(__get_response_body(body, body_content, None))
+
+    if 'content' in response_content:
+        for body, body_content in response_content['content'].items():
+            bodies.append(__get_response_body(body, body_content, None))
+
     return bodies


### PR DESCRIPTION
The `content` field of a response is optional (e.g. redirect responses).
Added a check which avoids errors when parsing responses without content