### PR TITLE
Fix: table definition

### DIFF
--- a/converter/HeaderConverter.py
+++ b/converter/HeaderConverter.py
@@ -1,7 +1,21 @@
 from model.Header import Header
 
 
-def __get_header_from_components(header:str, header_content: dict, headers_components: dict) -> Header:
+def sanitize_markdown_table_cell(cell_content: str):
+    """
+    Replaces newline characters ("\n") and YAML-style newline characters ("\\n", which is a "\" symbol followed by a newline)
+    with the HTML tag "<br />".
+
+     This is required since the only method to create a newline inside a markdown table cell is using the HTML newline tag,
+     any other syntax will result in bad formatting styles.
+
+    :param cell_content: the YAML content to convert as a markdown cell
+    :return: the string with all the specified characters replaced by the "<br />" tag
+    """
+    return cell_content.replace("\\\n", "<br />").replace("\n", "<br />")
+
+
+def __get_header_from_components(header: str, header_content: dict, headers_components: dict) -> Header:
     h = Header(header)
     header_ref = header_content['$ref']
     header_ref_name = header_ref[header_ref.rfind('/') + 1:]
@@ -10,18 +24,20 @@ def __get_header_from_components(header:str, header_content: dict, headers_compo
     header_component = headers_components[header_ref_name]
     h.type = header_component['schema']['type']
     h.example = header_component['schema']['example']
-    h.description = (header_component['description']).strip("\n")
+    h.description = sanitize_markdown_table_cell(header_component['description'])
     return h
 
-def __get_header(header:str, header_content: dict, headers_components: dict) -> Header:
+
+def __get_header(header: str, header_content: dict, headers_components: dict) -> Header:
     if '$ref' in header_content:
         return __get_header_from_components(header, header_content, headers_components)
 
     h = Header(header)
     h.type = header_content['schema']['type']
     h.example = header_content['schema']['example']
-    h.description = header_content['description']
+    h.description = sanitize_markdown_table_cell(header_content['description'])
     return h
+
 
 def get_headers(response_content: dict, components: dict) -> list[Header]:
     headers_content = response_content['headers']


### PR DESCRIPTION
If the content of a table contained newlines,
converting them to the Markdown code generated
bad syntax. Added a sanitisation method which
replaces all the newline characters from the YAML
syntax to a `<br />` HTML tag